### PR TITLE
Cleanup pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,28 +14,27 @@
   <packaging>jar</packaging>
 
   <properties>
-    <java.version>17</java.version>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <bstats.version>3.0.1</bstats.version>
+    <microlib.version>3.2.0</microlib.version>
+
+    <paper.version>1.19.4-R0.1-SNAPSHOT</paper.version>
+    <essentialsx.version>2.19.7</essentialsx.version>
+    <placeholderapi.version>2.11.2</placeholderapi.version>
+    <authlib.version>3.3.39</authlib.version>
+    <worldguard.version>7.0.7</worldguard.version>
+    <protocollib.version>4.8.0</protocollib.version>
+    <item-nbt.version>2.11.1</item-nbt.version>
+    <lm-items.version>1.1.0</lm-items.version>
   </properties>
 
   <build>
     <defaultGoal>clean package</defaultGoal>
     <finalName>${project.name}-${project.version}</finalName>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.10.1</version>
-        <configuration>
-          <source>17</source>
-          <target>17</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>net.md-5</groupId>
-        <artifactId>specialsource-maven-plugin</artifactId>
-        <version>1.2.4</version>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
@@ -75,11 +74,6 @@
             </goals>
             <configuration>
               <createDependencyReducedPom>false</createDependencyReducedPom>
-              <artifactSet>
-                <includes>
-                  <include>*:*</include>
-                </includes>
-              </artifactSet>
             </configuration>
           </execution>
         </executions>
@@ -95,16 +89,16 @@
 
   <repositories>
     <repository>
+      <id>papermc</id>
+      <url>https://repo.papermc.io/repository/maven-public/</url>
+    </repository>
+    <repository>
       <id>essentials-releases</id>
       <url>https://repo.essentialsx.net/releases/</url>
     </repository>
     <repository>
       <id>placeholderapi</id>
       <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
-    </repository>
-    <repository>
-      <id>spigotmc-repo</id>
-      <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
     </repository>
     <repository>
       <id>sonatype</id>
@@ -125,77 +119,76 @@
   </repositories>
 
   <dependencies>
+    <!-- Dependencies which are shaded in LM -->
+    <dependency>
+      <groupId>com.github.lokka30</groupId>
+      <artifactId>MicroLib</artifactId>
+      <version>${microlib.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.bstats</groupId>
+      <artifactId>bstats-bukkit</artifactId>
+      <version>${bstats.version}</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- Compile-only dependencies -->
     <dependency>
       <groupId>net.essentialsx</groupId>
       <artifactId>EssentialsX</artifactId>
-      <version>2.19.7</version>
+      <version>${essentialsx.version}</version>
       <scope>provided</scope>
+      <!-- For some weird ass reason the essentials dependency, even though provided,
+      provides us spigot as a transitive dependency, which makes maven go wild! Even though
+      we do not compile essentials, we have to exclude it -->
+      <exclusions>
+        <exclusion>
+          <groupId>org.spigotmc</groupId>
+          <artifactId>spigot-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.papermc.paper</groupId>
       <artifactId>paper-api</artifactId>
-      <version>1.19.3-R0.1-SNAPSHOT</version>
+      <version>${paper.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>me.clip</groupId>
       <artifactId>placeholderapi</artifactId>
-      <version>2.11.2</version>
+      <version>${placeholderapi.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.mojang</groupId>
       <artifactId>authlib</artifactId>
-      <version>3.3.39</version>
+      <version>${authlib.version}</version>
       <scope>provided</scope>
-    </dependency>
-    <!--suppress VulnerableLibrariesLocal -->
-    <dependency>
-      <groupId>org.spigotmc</groupId>
-      <artifactId>spigot-api</artifactId>
-      <version>1.19.3-R0.1-SNAPSHOT</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.bstats</groupId>
-      <artifactId>bstats-bukkit</artifactId>
-      <version>3.0.1</version>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.sk89q.worldguard</groupId>
       <artifactId>worldguard-bukkit</artifactId>
-      <version>7.0.7</version>
+      <version>${worldguard.version}</version>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.github.lokka30</groupId>
-      <artifactId>MicroLib</artifactId>
-      <version>3.2.0</version>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.github.dmulloy2</groupId>
       <artifactId>ProtocolLib</artifactId>
-      <version>4.8.0</version>
+      <version>${protocollib.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>de.tr7zw</groupId>
       <artifactId>item-nbt-api-plugin</artifactId>
-      <version>2.11.1</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>2.10.1</version>
+      <version>${item-nbt.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.github.stumper66</groupId>
       <artifactId>LM_Items</artifactId>
-      <version>1.1.0</version>
+      <version>${lm-items.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Avoids maven abomination where you'd need to add more than needed dependencies
in order for LM to compile. This PR also hands out some good practices (for example
declaring depdendency versions as properties for easier dependency updates).