### PR TITLE
Fix getEntities radius exceeding loaded chunks causing async getEntities exception

### DIFF
--- a/levelledmobs-plugin/src/main/kotlin/io/github/arcaneplugins/levelledmobs/commands/subcommands/KillSubcommand.kt
+++ b/levelledmobs-plugin/src/main/kotlin/io/github/arcaneplugins/levelledmobs/commands/subcommands/KillSubcommand.kt
@@ -9,6 +9,7 @@ import io.github.arcaneplugins.levelledmobs.LevelledMobs
 import io.github.arcaneplugins.levelledmobs.MainCompanion
 import io.github.arcaneplugins.levelledmobs.commands.MessagesHelper
 import io.github.arcaneplugins.levelledmobs.misc.RequestedLevel
+import io.github.arcaneplugins.levelledmobs.util.MiscUtils
 import io.github.arcaneplugins.levelledmobs.util.Utils
 import io.github.arcaneplugins.levelledmobs.wrappers.LivingEntityWrapper
 import org.bukkit.Bukkit
@@ -207,16 +208,15 @@ object KillSubcommand {
         var killed = 0
         var skipped = 0
         val mobsToKill: Collection<Entity>
+
         if (sender is BlockCommandSender) {
             val block = sender.block
+            val finalRadius = MiscUtils.retrieveLoadedChunkRadius(block.location, radius.toDouble())
             mobsToKill = block.world
-                .getNearbyEntities(block.location, radius.toDouble(), radius.toDouble(), radius.toDouble())
+                .getNearbyEntities(block.location, finalRadius, finalRadius, finalRadius)
         } else {
-            mobsToKill = (sender as Player).getNearbyEntities(
-                radius.toDouble(),
-                radius.toDouble(),
-                radius.toDouble()
-            )
+            val finalRadius = MiscUtils.retrieveLoadedChunkRadius((sender as Player).location, radius.toDouble())
+            mobsToKill = sender.getNearbyEntities(finalRadius, finalRadius, finalRadius)
         }
 
         for (entity in mobsToKill) {

--- a/levelledmobs-plugin/src/main/kotlin/io/github/arcaneplugins/levelledmobs/listeners/EntitySpawnListener.kt
+++ b/levelledmobs-plugin/src/main/kotlin/io/github/arcaneplugins/levelledmobs/listeners/EntitySpawnListener.kt
@@ -14,6 +14,7 @@ import io.github.arcaneplugins.levelledmobs.misc.NamespacedKeys
 import io.github.arcaneplugins.levelledmobs.misc.QueueItem
 import io.github.arcaneplugins.levelledmobs.result.AdditionalLevelInformation
 import io.github.arcaneplugins.levelledmobs.util.Log
+import io.github.arcaneplugins.levelledmobs.util.MiscUtils
 import io.github.arcaneplugins.levelledmobs.util.Utils
 import io.github.arcaneplugins.levelledmobs.wrappers.LivingEntityWrapper
 import io.github.arcaneplugins.levelledmobs.wrappers.SchedulerWrapper
@@ -516,7 +517,8 @@ class EntitySpawnListener : Listener{
             mob: LivingEntity,
             checkDistance: Int
         ): MutableList<Player> {
-            var temp = mob.getNearbyEntities(checkDistance.toDouble(), checkDistance.toDouble(), checkDistance.toDouble()
+            val radius = MiscUtils.retrieveLoadedChunkRadius(mob.location, checkDistance.toDouble())
+            var temp = mob.getNearbyEntities(radius, radius, radius
             ).asSequence()
                 .filterIsInstance<Player>()
                 .filter { e: Entity -> (e as Player).gameMode != GameMode.SPECTATOR }

--- a/levelledmobs-plugin/src/main/kotlin/io/github/arcaneplugins/levelledmobs/managers/LevelManager.kt
+++ b/levelledmobs-plugin/src/main/kotlin/io/github/arcaneplugins/levelledmobs/managers/LevelManager.kt
@@ -1142,10 +1142,10 @@ class LevelManager : LevelInterface2 {
         var checkDistance = entitySpawnListener.mobCheckDistance.toDouble()
 
         for (player in Bukkit.getOnlinePlayers()) {
-            checkDistance = retrieveLoadedChunkRadius(player, checkDistance)
             if (LevelledMobs.instance.ver.isRunningFolia) {
                 asyncRunningCount.getAndIncrement()
                 val scheduler = SchedulerWrapper(player) {
+                    checkDistance = retrieveLoadedChunkRadius(player, checkDistance)
                     val entities = player.getNearbyEntities(
                         checkDistance, checkDistance, checkDistance
                     )

--- a/levelledmobs-plugin/src/main/kotlin/io/github/arcaneplugins/levelledmobs/managers/LevelManager.kt
+++ b/levelledmobs-plugin/src/main/kotlin/io/github/arcaneplugins/levelledmobs/managers/LevelManager.kt
@@ -1104,38 +1104,6 @@ class LevelManager : LevelInterface2 {
         }
     }
 
-    private fun retrieveLoadedChunkRadius(player: Player, expect: Double): Double {
-        val world = player.world
-        val centerX:Int = (player.location.x / 16).toInt()
-        val centerZ:Int = (player.location.z / 16).toInt()
-        var maxChunkRadius = 0
-
-        outer@ while (true) {
-            val currentRadius = maxChunkRadius + 1
-            if (currentRadius * 16 > expect) break
-            for (dx in -currentRadius..currentRadius) {
-                if (!world.isChunkLoaded(centerX + dx, centerZ - currentRadius)) {
-                    break@outer
-                }
-                if (!world.isChunkLoaded(centerX + dx, centerZ + currentRadius)) {
-                    break@outer
-                }
-            }
-
-            for (dz in (-currentRadius + 1) until currentRadius) {
-                if (!world.isChunkLoaded(centerX - currentRadius, centerZ + dz)) {
-                    break@outer
-                }
-                if (!world.isChunkLoaded(centerX + currentRadius, centerZ + dz)) {
-                    break@outer
-                }
-            }
-            maxChunkRadius = currentRadius
-        }
-
-        return (maxChunkRadius * 16.0).coerceAtMost(expect)
-    }
-
     private fun enumerateNearbyEntities() {
         entitiesPerPlayer.clear()
         asyncRunningCount.set(0)
@@ -1145,7 +1113,7 @@ class LevelManager : LevelInterface2 {
             if (LevelledMobs.instance.ver.isRunningFolia) {
                 asyncRunningCount.getAndIncrement()
                 val scheduler = SchedulerWrapper(player) {
-                    checkDistance = retrieveLoadedChunkRadius(player, checkDistance)
+                    checkDistance = MiscUtils.retrieveLoadedChunkRadius(player.location, checkDistance)
                     val entities = player.getNearbyEntities(
                         checkDistance, checkDistance, checkDistance
                     )

--- a/levelledmobs-plugin/src/main/kotlin/io/github/arcaneplugins/levelledmobs/managers/LevelManager.kt
+++ b/levelledmobs-plugin/src/main/kotlin/io/github/arcaneplugins/levelledmobs/managers/LevelManager.kt
@@ -1104,12 +1104,45 @@ class LevelManager : LevelInterface2 {
         }
     }
 
+    private fun retrieveLoadedChunkRadius(player: Player, expect: Double): Double {
+        val world = player.world
+        val centerX:Int = (player.location.x / 16).toInt()
+        val centerZ:Int = (player.location.z / 16).toInt()
+        var maxChunkRadius = 0
+
+        outer@ while (true) {
+            val currentRadius = maxChunkRadius + 1
+            if (currentRadius * 16 > expect) break
+            for (dx in -currentRadius..currentRadius) {
+                if (!world.isChunkLoaded(centerX + dx, centerZ - currentRadius)) {
+                    break@outer
+                }
+                if (!world.isChunkLoaded(centerX + dx, centerZ + currentRadius)) {
+                    break@outer
+                }
+            }
+
+            for (dz in (-currentRadius + 1) until currentRadius) {
+                if (!world.isChunkLoaded(centerX - currentRadius, centerZ + dz)) {
+                    break@outer
+                }
+                if (!world.isChunkLoaded(centerX + currentRadius, centerZ + dz)) {
+                    break@outer
+                }
+            }
+            maxChunkRadius = currentRadius
+        }
+
+        return (maxChunkRadius * 16.0).coerceAtMost(expect)
+    }
+
     private fun enumerateNearbyEntities() {
         entitiesPerPlayer.clear()
         asyncRunningCount.set(0)
-        val checkDistance = entitySpawnListener.mobCheckDistance.toDouble()
+        var checkDistance = entitySpawnListener.mobCheckDistance.toDouble()
 
         for (player in Bukkit.getOnlinePlayers()) {
+            checkDistance = retrieveLoadedChunkRadius(player, checkDistance)
             if (LevelledMobs.instance.ver.isRunningFolia) {
                 asyncRunningCount.getAndIncrement()
                 val scheduler = SchedulerWrapper(player) {

--- a/levelledmobs-plugin/src/main/kotlin/io/github/arcaneplugins/levelledmobs/managers/PlaceholderApiIntegration.kt
+++ b/levelledmobs-plugin/src/main/kotlin/io/github/arcaneplugins/levelledmobs/managers/PlaceholderApiIntegration.kt
@@ -6,6 +6,7 @@ import io.github.arcaneplugins.levelledmobs.LevelledMobs
 import io.github.arcaneplugins.levelledmobs.misc.LastMobKilledInfo
 import io.github.arcaneplugins.levelledmobs.misc.StringReplacer
 import io.github.arcaneplugins.levelledmobs.util.MessageUtils.colorizeAll
+import io.github.arcaneplugins.levelledmobs.util.MiscUtils
 import io.github.arcaneplugins.levelledmobs.wrappers.LivingEntityWrapper
 import org.bukkit.entity.LivingEntity
 import org.bukkit.entity.Player
@@ -167,7 +168,8 @@ class PlaceholderApiIntegration : PlaceholderExpansion() {
             "nametag-placeholder-maxblocks", 30
         )
 
-        for (entity in player.getNearbyEntities(maxBlocks.toDouble(), maxBlocks.toDouble(), maxBlocks.toDouble())) {
+        val radius = MiscUtils.retrieveLoadedChunkRadius(player.location, maxBlocks.toDouble())
+        for (entity in player.getNearbyEntities(radius, radius, radius)) {
             if (entity !is LivingEntity) {
                 continue
             }

--- a/levelledmobs-plugin/src/main/kotlin/io/github/arcaneplugins/levelledmobs/util/MiscUtils.kt
+++ b/levelledmobs-plugin/src/main/kotlin/io/github/arcaneplugins/levelledmobs/util/MiscUtils.kt
@@ -11,6 +11,39 @@ import org.bukkit.entity.LivingEntity
  * @since 3.11.0
  */
 object MiscUtils {
+
+     fun retrieveLoadedChunkRadius(location: org.bukkit.Location, expect: Double): Double {
+        val world = location.world
+        val centerX:Int = (location.x / 16).toInt()
+        val centerZ:Int = (location.z / 16).toInt()
+        var maxChunkRadius = 0
+
+        outer@ while (true) {
+            val currentRadius = maxChunkRadius + 1
+            if (currentRadius * 16 > expect) break
+            for (dx in -currentRadius..currentRadius) {
+                if (!world.isChunkLoaded(centerX + dx, centerZ - currentRadius)) {
+                    break@outer
+                }
+                if (!world.isChunkLoaded(centerX + dx, centerZ + currentRadius)) {
+                    break@outer
+                }
+            }
+
+            for (dz in (-currentRadius + 1) until currentRadius) {
+                if (!world.isChunkLoaded(centerX - currentRadius, centerZ + dz)) {
+                    break@outer
+                }
+                if (!world.isChunkLoaded(centerX + currentRadius, centerZ + dz)) {
+                    break@outer
+                }
+            }
+            maxChunkRadius = currentRadius
+        }
+
+        return (maxChunkRadius * 16.0).coerceAtMost(expect)
+    }
+
     fun getNBTDump(
         livingEntity: LivingEntity
     ): String {


### PR DESCRIPTION
fix async getEntities exception was thrown if chunk is not fully loaded around player in folia server