### PR TITLE
Fix end levelling strategy

### DIFF
--- a/levelledmobs-plugin/src/main/resources/rules.yml
+++ b/levelledmobs-plugin/src/main/resources/rules.yml
@@ -403,9 +403,9 @@ custom-rules:
       worlds: 'world_the_end'
     strategies:
       distance-from-origin:
-        increase-level-distance: 200
-        start-distance: 1000
-        spawn-location:
+        ringed-tiers: 200
+        buffer-distance: 1000
+        origin-coordinates:
           x: 0
           z: 0
     settings:


### PR DESCRIPTION
As far as I can tell, the default end world levelling strategy uses incorrect syntax for the `distance-from-origin` strategy. On my server, this caused mobs in the end to increase a level *every block* away from 0, 0, rather than every 200 blocks as intended.